### PR TITLE
Bug fix for certain motions. Re-org of includes.

### DIFF
--- a/config.h
+++ b/config.h
@@ -32,7 +32,6 @@
 
 #ifndef config_h
 #define config_h
-#include "system.h"
 
 
 // Default settings. Used when resetting EEPROM. Change to desired name in defaults.h

--- a/coolant_control.c
+++ b/coolant_control.c
@@ -18,10 +18,7 @@
   along with Grbl.  If not, see <http://www.gnu.org/licenses/>.
 */  
 
-#include "system.h"
-#include "coolant_control.h"
-#include "protocol.h"
-#include "gcode.h"
+#include "grbl.h"
 
 
 void coolant_init()

--- a/examples/Grbl/Grbl.ino
+++ b/examples/Grbl/Grbl.ino
@@ -1,0 +1,22 @@
+#include <config.h>
+#include <coolant_control.h>
+#include <cpu_map.h>
+#include <defaults.h>
+#include <eeprom.h>
+#include <gcode.h>
+#include <grbl.h>
+#include <limits.h>
+#include <motion_control.h>
+#include <nuts_bolts.h>
+#include <planner.h>
+#include <print.h>
+#include <probe.h>
+#include <protocol.h>
+#include <report.h>
+#include <serial.h>
+#include <settings.h>
+#include <spindle_control.h>
+#include <stepper.h>
+#include <system.h>
+
+#include <src/main.h>

--- a/gcode.c
+++ b/gcode.c
@@ -24,15 +24,7 @@
     Copyright (c) 2011-2012 Sungeun K. Jeon
 */  
 
-#include "system.h"
-#include "settings.h"
-#include "protocol.h"
-#include "gcode.h"
-#include "motion_control.h"
-#include "spindle_control.h"
-#include "coolant_control.h"
-#include "probe.h"
-#include "report.h"
+#include "grbl.h"
 
 // NOTE: Max line number is defined by the g-code standard to be 99999. It seems to be an
 // arbitrary value, and some GUIs may require more. So we increased it based on a max safe

--- a/grbl.h
+++ b/grbl.h
@@ -25,25 +25,41 @@
 #ifndef grbl_h
 #define grbl_h
 
-// All of the Grbl system include files.
+#define GRBL_VERSION "0.9h"
+#define GRBL_VERSION_BUILD "20150210"
+
+// Define standard libraries used by Grbl.
+#include <avr/io.h>
+#include <avr/pgmspace.h>
+#include <avr/interrupt.h>
+#include <avr/wdt.h>
+#include <util/delay.h>
+#include <math.h>
+#include <inttypes.h>    
+#include <string.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+// Define the Grbl system include files.
 #include "config.h"
-#include "coolant_control.h"
-#include "cpu_map.h"
+#include "nuts_bolts.h"
+#include "settings.h"
+#include "system.h"
 #include "defaults.h"
+#include "cpu_map.h"
+#include "coolant_control.h"
 #include "eeprom.h"
 #include "gcode.h"
 #include "limits.h"
 #include "motion_control.h"
-#include "nuts_bolts.h"
 #include "planner.h"
 #include "print.h"
 #include "probe.h"
 #include "protocol.h"
 #include "report.h"
 #include "serial.h"
-#include "settings.h"
 #include "spindle_control.h"
 #include "stepper.h"
-#include "system.h"
 
 #endif

--- a/limits.c
+++ b/limits.c
@@ -24,14 +24,8 @@
     Copyright (c) 2012 Sungeun K. Jeon
 */  
   
-#include "system.h"
-#include "settings.h"
-#include "protocol.h"
-#include "planner.h"
-#include "stepper.h"
-#include "motion_control.h"
-#include "limits.h"
-#include "report.h"
+#include "grbl.h"
+
 
 // Homing axis search distance multiplier. Computed by this value times the axis max travel.
 #define HOMING_AXIS_SEARCH_SCALAR  1.5 // Must be > 1 to ensure limit switch will be engaged.

--- a/main.c
+++ b/main.c
@@ -24,19 +24,7 @@
     Copyright (c) 2011-2012 Sungeun K. Jeon
 */  
 
-#include "system.h"
-#include "serial.h"
-#include "settings.h"
-#include "protocol.h"
-#include "gcode.h"
-#include "planner.h"
-#include "stepper.h"
-#include "spindle_control.h"
-#include "coolant_control.h"
-#include "motion_control.h"
-#include "limits.h"
-#include "probe.h"
-#include "report.h"
+#include "grbl.h"
 
 
 // Declare system global variable structure

--- a/motion_control.c
+++ b/motion_control.c
@@ -25,18 +25,7 @@
     Copyright (c) 2011 Jens Geisler
 */  
 
-#include "system.h"
-#include "settings.h"
-#include "protocol.h"
-#include "gcode.h"
-#include "planner.h"
-#include "stepper.h"
-#include "motion_control.h"
-#include "spindle_control.h"
-#include "coolant_control.h"
-#include "limits.h"
-#include "probe.h"
-#include "report.h"
+#include "grbl.h"
 
 
 // Execute linear motion in absolute millimeter coordinates. Feed rate given in millimeters/second

--- a/motion_control.h
+++ b/motion_control.h
@@ -26,7 +26,7 @@
 
 #ifndef motion_control_h
 #define motion_control_h
-#include "gcode.h"
+
 
 #define HOMING_CYCLE_LINE_NUMBER -1
 

--- a/nuts_bolts.c
+++ b/nuts_bolts.c
@@ -24,8 +24,7 @@
     Copyright (c) 2011-2012 Sungeun K. Jeon
 */ 
 
-#include "system.h"
-#include "print.h"
+#include "grbl.h"
 
 
 #define MAX_INT_DIGITS 8 // Maximum number of digits in int32 (and float)

--- a/print.c
+++ b/print.c
@@ -24,9 +24,7 @@
     Copyright (c) 2011-2012 Sungeun K. Jeon
 */ 
 
-#include "system.h"
-#include "serial.h"
-#include "settings.h"
+#include "grbl.h"
 
 
 void printString(const char *s)

--- a/probe.c
+++ b/probe.c
@@ -18,9 +18,8 @@
   along with Grbl.  If not, see <http://www.gnu.org/licenses/>.
 */
   
-#include "system.h"
-#include "settings.h"
-#include "probe.h"
+#include "grbl.h"
+
 
 // Inverts the probe pin state depending on user settings and probing cycle mode.
 uint8_t probe_invert_mask;

--- a/protocol.c
+++ b/protocol.c
@@ -24,15 +24,7 @@
     Copyright (c) 2011-2012 Sungeun K. Jeon
 */ 
 
-#include "system.h"
-#include "serial.h"
-#include "settings.h"
-#include "protocol.h"
-#include "gcode.h"
-#include "planner.h"
-#include "stepper.h"
-#include "motion_control.h"
-#include "report.h"
+#include "grbl.h"
 
 
 static char line[LINE_BUFFER_SIZE]; // Line to be executed. Zero-terminated.

--- a/report.c
+++ b/report.c
@@ -26,16 +26,7 @@
   methods to accomodate their needs.
 */
 
-#include "system.h"
-#include "report.h"
-#include "print.h"
-#include "settings.h"
-#include "gcode.h"
-#include "coolant_control.h"
-#include "planner.h"
-#include "spindle_control.h"
-#include "stepper.h"
-#include "serial.h"
+#include "grbl.h"
 
 
 // Handles the primary confirmation protocol response for streaming interfaces and human-feedback.

--- a/serial.c
+++ b/serial.c
@@ -24,11 +24,7 @@
     Copyright (c) 2011-2012 Sungeun K. Jeon
 */ 
 
-#include <avr/interrupt.h>
-#include "system.h"
-#include "serial.h"
-#include "motion_control.h"
-#include "protocol.h"
+#include "grbl.h"
 
 
 uint8_t serial_rx_buffer[RX_BUFFER_SIZE];

--- a/settings.c
+++ b/settings.c
@@ -24,13 +24,7 @@
     Copyright (c) 2011-2012 Sungeun K. Jeon
 */ 
 
-#include "system.h"
-#include "settings.h"
-#include "eeprom.h"
-#include "protocol.h"
-#include "report.h"
-#include "limits.h"
-#include "stepper.h"
+#include "grbl.h"
 
 settings_t settings;
 

--- a/settings.h
+++ b/settings.h
@@ -27,9 +27,8 @@
 #ifndef settings_h
 #define settings_h
 
+#include "grbl.h"
 
-#define GRBL_VERSION "0.9h"
-#define GRBL_VERSION_BUILD "20150204"
 
 // Version of the EEPROM data. Will be used to migrate existing data from older versions of Grbl
 // when firmware is upgraded. Always stored in byte 0 of eeprom

--- a/spindle_control.c
+++ b/spindle_control.c
@@ -24,10 +24,7 @@
     Copyright (c) 2012 Sungeun K. Jeon
 */ 
 
-#include "system.h"
-#include "spindle_control.h"
-#include "protocol.h"
-#include "gcode.h"
+#include "grbl.h"
 
 
 void spindle_init()

--- a/stepper.c
+++ b/stepper.c
@@ -24,12 +24,7 @@
     Copyright (c) 2011-2012 Sungeun K. Jeon
 */ 
 
-#include "system.h"
-#include "nuts_bolts.h"
-#include "stepper.h"
-#include "settings.h"
-#include "planner.h"
-#include "probe.h"
+#include "grbl.h"
 
 
 // Some useful constants.

--- a/system.c
+++ b/system.c
@@ -18,14 +18,7 @@
   along with Grbl.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "system.h"
-#include "settings.h"
-#include "protocol.h"
-#include "gcode.h"
-#include "motion_control.h"
-#include "stepper.h"
-#include "report.h"
-#include "print.h"
+#include "grbl.h"
 
 
 void system_init() 

--- a/system.h
+++ b/system.h
@@ -21,25 +21,7 @@
 #ifndef system_h
 #define system_h
 
-// Define system header files and standard libraries used by Grbl
-#include <avr/io.h>
-#include <avr/pgmspace.h>
-#include <avr/interrupt.h>
-#include <avr/wdt.h>
-#include <util/delay.h>
-#include <math.h>
-#include <inttypes.h>    
-#include <string.h>
-#include <stdlib.h>
-#include <stdint.h>
-#include <stdbool.h>
-
-// Define Grbl configuration and shared header files
-#include "config.h"
-#include "defaults.h"
-#include "cpu_map.h"
-#include "nuts_bolts.h"
-
+#include "grbl.h"
 
 // Define system executor bit map. Used internally by realtime protocol as realtime command flags, 
 // which notifies the main program to execute the specified realtime command asynchronously.


### PR DESCRIPTION
- Critical bug fix for diagonal motions that continue on the same
  direction or return in the exact opposite direction. This issue could
  cause Grbl to crash intermittently due to a numerical round-off error.
  Grbl versions prior to v0.9g shouldn’t have this issue.
- Reorganized all of the includes used by Grbl. Centralized it into a
  single “grbl.h” include. This will help simplify the compiling and
  uploading process through the Arduino IDE.
- Added an example .INO file for users to simply open and run when
  compiling and uploading through the IDE. More to come later.
